### PR TITLE
Point to production app URL for display

### DIFF
--- a/scripts/run_smart_mirror_display.sh
+++ b/scripts/run_smart_mirror_display.sh
@@ -20,7 +20,7 @@ SUB='True'
 if [[ "$EVAL" == *"$SUB"* ]];
 then
 #   Connected to the internet
-  DISPLAY=:0.0 chromium-browser --noerrdialogs --disable-infobars --incognito --disable-gpu --kiosk https://smart-mirror-13618.web.app/\#/display-page/$DISPLAY_DEVICE_NAME &
+  DISPLAY=:0.0 chromium-browser --noerrdialogs --disable-infobars --incognito --disable-gpu --kiosk https://impiam.web.app/\#/display-page/$DISPLAY_DEVICE_NAME &
 
 else
 #   Not connected to the internet


### PR DESCRIPTION
### Description
- Pointing to the production Impiam web app, instead of the dev Impiam web app
- [Shortcut story here](https://app.shortcut.com/impiam/story/201/update-gatt-server-to-point-to-prod-url)